### PR TITLE
Update minus sign character

### DIFF
--- a/SnappingStepper/SnappingStepper.swift
+++ b/SnappingStepper/SnappingStepper.swift
@@ -284,7 +284,7 @@ import UIKit
   // MARK: - Managing the Components
 
   func initComponents() {
-    minusSymbolLabel.text      = "-"
+    minusSymbolLabel.text      = "−"
     minusSymbolLabel.font      = symbolFont
     minusSymbolLabel.textColor = symbolFontColor
     addSubview(minusSymbolLabel)


### PR DESCRIPTION
Use the unicode “minus sign” symbol, instead of the “dash” from the classic keyboard. 

The difference isn’t visible on GitHub, or with most fixed-space fonts, but you can see the result when run on iOS.
