### PR TITLE
Removed "final" on StyledLabel

### DIFF
--- a/Sources/StyledLabel.swift
+++ b/Sources/StyledLabel.swift
@@ -30,7 +30,7 @@
 import UIKit
 
 /// The `StyledLabel` object is an `UILabel` with a custom shape.
-public final class StyledLabel: UIView {
+public class StyledLabel: UIView {
   var label                = UILabel()
   var styleColor: UIColor? = UIColor.clearColor()
   var shapeLayer           = CAShapeLayer()


### PR DESCRIPTION
I am creating a new component, which depends on this control and I would like to use the same styling elements in order to have matching styles. The new component needs to derive from the StyledLabel (extension is not adequate), so it would be nice if the "final" declaration is removed from StyledLabel.
