### PR TITLE
Added vertical layout option through setting the direction parameter

### DIFF
--- a/Example/SnappingStepperExample.xcodeproj/project.pbxproj
+++ b/Example/SnappingStepperExample.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		01AA9210AD07C825DAE1F607 /* Pods_SnappingStepperExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 449D06ECFFEC0DD8C4DA6EF2 /* Pods_SnappingStepperExample.framework */; };
 		0D1DA54DFA51DA8D2A48E14A /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09E3430E9EA28A5D0C4ED262 /* Pods_Tests.framework */; };
+		5B1EFC7E1D71932E0040AD50 /* StyledControlDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EFC7D1D71932E0040AD50 /* StyledControlDirection.swift */; };
+		5B1EFC7F1D71932E0040AD50 /* StyledControlDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EFC7D1D71932E0040AD50 /* StyledControlDirection.swift */; };
+		5B1EFC801D71932E0040AD50 /* StyledControlDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EFC7D1D71932E0040AD50 /* StyledControlDirection.swift */; };
 		5E1F7E9CB92461FE26B43DF2 /* Pods_SnappingStepper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 921B58F6F24292F873D6FE4A /* Pods_SnappingStepper.framework */; };
 		CE132D681D0880EB00CA6DB5 /* UIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132D671D0880EB00CA6DB5 /* UIBuilder.swift */; };
 		CE132D691D0880EB00CA6DB5 /* UIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132D671D0880EB00CA6DB5 /* UIBuilder.swift */; };
@@ -83,6 +86,7 @@
 		09E3430E9EA28A5D0C4ED262 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B63928ED40BD6C1AAE23668 /* Pods_UITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		449D06ECFFEC0DD8C4DA6EF2 /* Pods_SnappingStepperExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnappingStepperExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B1EFC7D1D71932E0040AD50 /* StyledControlDirection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StyledControlDirection.swift; sourceTree = "<group>"; };
 		7C4C30B228B621354D490313 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		8B6D05BEEE35E75A880B7639 /* Pods-SnappingStepperExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnappingStepperExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-SnappingStepperExample/Pods-SnappingStepperExample.release.xcconfig"; sourceTree = "<group>"; };
 		921B58F6F24292F873D6FE4A /* Pods_SnappingStepper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SnappingStepper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -143,6 +147,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5B1EFC7C1D7192FE0040AD50 /* ThirdParty */ = {
+			isa = PBXGroup;
+			children = (
+				5B1EFC7D1D71932E0040AD50 /* StyledControlDirection.swift */,
+			);
+			name = ThirdParty;
+			sourceTree = "<group>";
+		};
 		B7F47D86834F3F549B39F8F8 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -212,6 +224,7 @@
 		CE972EE61D044B7E00EDE4A7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				5B1EFC7C1D7192FE0040AD50 /* ThirdParty */,
 				CE972F031D0453D800EDE4A7 /* AutoRepeatHelper.swift */,
 				CE972EE71D044B7E00EDE4A7 /* CustomShapeLayer.swift */,
 				CE972EE81D044B7E00EDE4A7 /* ShapeStyle.swift */,
@@ -531,6 +544,7 @@
 			files = (
 				CE6F72401AF513810019CB55 /* ViewController.swift in Sources */,
 				CE972EF81D044B7E00EDE4A7 /* StyledLabel.swift in Sources */,
+				5B1EFC7E1D71932E0040AD50 /* StyledControlDirection.swift in Sources */,
 				CE972EF41D044B7E00EDE4A7 /* SnappingStepper.swift in Sources */,
 				CE972EF01D044B7E00EDE4A7 /* ShapeStyle.swift in Sources */,
 				CE972EEE1D044B7E00EDE4A7 /* CustomShapeLayer.swift in Sources */,
@@ -547,6 +561,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B1EFC7F1D71932E0040AD50 /* StyledControlDirection.swift in Sources */,
 				CE972EEF1D044B7E00EDE4A7 /* CustomShapeLayer.swift in Sources */,
 				CE972EF91D044B7E00EDE4A7 /* StyledLabel.swift in Sources */,
 				CE972EF31D044B7E00EDE4A7 /* SnappingStepper+Internal.swift in Sources */,
@@ -567,6 +582,7 @@
 				CE972EFF1D044B8200EDE4A7 /* SnappingStepper.swift in Sources */,
 				CE972EFD1D044B8200EDE4A7 /* ShapeStyle.swift in Sources */,
 				CE972EFC1D044B8200EDE4A7 /* CustomShapeLayer.swift in Sources */,
+				5B1EFC801D71932E0040AD50 /* StyledControlDirection.swift in Sources */,
 				CEB21D691B18C18A003E9EEC /* SnappingStepperTests.swift in Sources */,
 				CE132D6A1D08810C00CA6DB5 /* UIBuilder.swift in Sources */,
 				CE972F021D044B8200EDE4A7 /* UITouchGestureRecognizer.swift in Sources */,
@@ -648,7 +664,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -687,7 +703,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -731,7 +747,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SnappingStepper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yannickloriot.SnappingStepper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -752,7 +768,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SnappingStepper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.yannickloriot.SnappingStepper;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/SnappingStepperExample/Base.lproj/Main.storyboard
+++ b/Example/SnappingStepperExample/Base.lproj/Main.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
@@ -118,11 +117,28 @@
                                             <action selector="stepperValueChangedAction:" destination="BYZ-38-t0r" eventType="valueChanged" id="QAl-kp-giM"/>
                                         </connections>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aSQ-lY-OYI" customClass="SnappingStepper" customModule="SnappingStepperExample" customModuleProvider="target">
+                                        <rect key="frame" x="193" y="12" width="49" height="136"/>
+                                        <color key="backgroundColor" red="0.20392156859999999" green="0.59999999999999998" blue="0.61176470589999998" alpha="1" colorSpace="custom" customColorSpace="adobeRGB1998"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="49" id="Ey0-ER-exA"/>
+                                            <constraint firstAttribute="height" constant="136" id="paB-bp-RwN"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="symbolFontColor">
+                                                <color key="value" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="stepperValueChangedAction:" destination="BYZ-38-t0r" eventType="valueChanged" id="fVu-Il-q3v"/>
+                                        </connections>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="ziz-Bb-wQ4" firstAttribute="top" secondItem="QWu-3t-c5V" secondAttribute="bottom" constant="8" id="3LE-9o-hSi"/>
                                     <constraint firstItem="PCK-qc-iIc" firstAttribute="leading" secondItem="Yv1-gG-72y" secondAttribute="leading" id="3Vh-aQ-Iih"/>
+                                    <constraint firstItem="aSQ-lY-OYI" firstAttribute="top" secondItem="vQ2-aN-ZzV" secondAttribute="top" id="45b-BS-Ygs"/>
                                     <constraint firstAttribute="centerX" secondItem="p4I-GE-yJd" secondAttribute="centerX" id="6BB-Vm-jjs"/>
                                     <constraint firstItem="ziz-Bb-wQ4" firstAttribute="centerX" secondItem="p4I-GE-yJd" secondAttribute="centerX" id="8Gj-az-6Ie"/>
                                     <constraint firstItem="p4I-GE-yJd" firstAttribute="top" secondItem="Ix2-NP-H0n" secondAttribute="top" constant="156" id="8O0-F9-1cp"/>
@@ -134,6 +150,7 @@
                                     <constraint firstAttribute="width" constant="250" id="Vk5-e3-rCF"/>
                                     <constraint firstItem="PCK-qc-iIc" firstAttribute="top" secondItem="vQ2-aN-ZzV" secondAttribute="bottom" constant="8" symbolic="YES" id="fgN-jL-3Pr"/>
                                     <constraint firstAttribute="centerX" secondItem="QWu-3t-c5V" secondAttribute="centerX" id="fuF-Hb-mu4"/>
+                                    <constraint firstItem="aSQ-lY-OYI" firstAttribute="leading" secondItem="vQ2-aN-ZzV" secondAttribute="trailing" constant="8" symbolic="YES" id="iKj-YE-Vpa"/>
                                     <constraint firstItem="p4I-GE-yJd" firstAttribute="top" secondItem="Yv1-gG-72y" secondAttribute="bottom" constant="8" symbolic="YES" id="laf-Fb-y6M"/>
                                 </constraints>
                             </view>
@@ -153,6 +170,7 @@
                         <outlet property="roundedStepper" destination="PCK-qc-iIc" id="ncp-uI-Unr"/>
                         <outlet property="tubeStepper" destination="Yv1-gG-72y" id="ObT-4Z-2io"/>
                         <outlet property="valueLabel" destination="QWu-3t-c5V" id="adl-kG-xnR"/>
+                        <outlet property="verticalRoundedStepper" destination="aSQ-lY-OYI" id="T3z-Tu-4YC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Example/SnappingStepperExample/ViewController.swift
+++ b/Example/SnappingStepperExample/ViewController.swift
@@ -16,7 +16,8 @@ class ViewController: UIViewController {
   @IBOutlet weak var tubeStepper: SnappingStepper!
   @IBOutlet weak var roundedStepper: SnappingStepper!
   @IBOutlet weak var customStepper: SnappingStepper!
-
+  @IBOutlet weak var verticalRoundedStepper: SnappingStepper!
+    
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -46,6 +47,16 @@ class ViewController: UIViewController {
     customStepper.thumbBackgroundColor = UIColor(hex: 0x607D8B)
     customStepper.borderWidth          = 0.5
     customStepper.hintStyle            = .Rounded
+    
+    assignStepperDefaultSettings(verticalRoundedStepper)
+    verticalRoundedStepper.style                = .Rounded
+    verticalRoundedStepper.thumbStyle           = .Rounded
+    verticalRoundedStepper.backgroundColor      = .clearColor()
+    verticalRoundedStepper.thumbBackgroundColor = UIColor(hex: 0xFFC107)
+    verticalRoundedStepper.borderColor          = UIColor(hex: 0xFFC107)
+    verticalRoundedStepper.borderWidth          = 0.5
+    verticalRoundedStepper.hintStyle            = .Thumb
+    verticalRoundedStepper.direction            = .Vertical
   }
 
   func assignStepperDefaultSettings(snappingStepper: SnappingStepper) {
@@ -99,7 +110,7 @@ class ViewController: UIViewController {
   }
 
   @IBAction func stepperValueChangedAction(sender: SnappingStepper) {
-    for stepper in [classicStepper, tubeStepper, roundedStepper, customStepper] {
+    for stepper in [classicStepper, tubeStepper, roundedStepper, verticalRoundedStepper, customStepper] {
       if stepper != sender {
         stepper.value = sender.value
       }
@@ -113,5 +124,6 @@ class ViewController: UIViewController {
     updateThumbAttributes(customStepper, index: sender.selectedSegmentIndex)
     updateThumbAttributes(tubeStepper, index: sender.selectedSegmentIndex)
     updateThumbAttributes(roundedStepper, index: sender.selectedSegmentIndex)
+    updateThumbAttributes(verticalRoundedStepper, index: sender.selectedSegmentIndex)
   }
 }

--- a/Sources/CustomShapeLayer.swift
+++ b/Sources/CustomShapeLayer.swift
@@ -60,6 +60,8 @@ final class CustomShapeLayer {
       path = UIBezierPath(rect: bounds)
     case .Rounded:
       path = UIBezierPath(roundedRect: bounds, cornerRadius: max(1.0, min(bounds.size.width, bounds.size.height) * 0.2))
+    case .RoundedFixed(let cornerRadius):
+      path = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius)
     case .Thumb:
       let s    = min(bounds.size.width, bounds.size.height)
       let xOff = (bounds.size.width - s) * 0.5

--- a/Sources/ShapeStyle.swift
+++ b/Sources/ShapeStyle.swift
@@ -37,6 +37,8 @@ public enum ShapeStyle {
   case Box
   /// A round shape.
   case Rounded
+  /// A round shape with given corner radius.
+  case RoundedFixed(cornerRadius: CGFloat)
   /// A thumb shape.
   case Thumb
   /// A tube shape.

--- a/Sources/SnappingStepper.swift
+++ b/Sources/SnappingStepper.swift
@@ -72,6 +72,17 @@ import UIKit
   @IBInspectable public var wraps: Bool = false
 
   /**
+   The direction of the control
+     
+   The default is horizontal
+  */
+  @IBInspectable public var direction: StyledControlDirection = .Horizontal {
+    didSet {
+      self.layoutComponents()
+    }
+  }
+    
+  /**
    The lowest possible numeric value for the stepper.
 
    Must be numerically less than maximumValue. If you attempt to set a value equal to or greater than maximumValue, the system raises an NSInvalidArgumentException exception.

--- a/Sources/StyledControlDirection.swift
+++ b/Sources/StyledControlDirection.swift
@@ -1,0 +1,108 @@
+// ORIGINAL COPYRIGHT NOTE / ORIGINATES FROM MJRFlexStyleComponents
+//
+//  StyledControlDirection.swift
+//  MJRFlexStyleComponents
+//
+//  Created by Martin Rehder on 16.07.16.
+/*
+ * Copyright 2016-present Martin Jacob Rehder.
+ * http://www.rehsco.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import UIKit
+
+public enum StyledControlDirection {
+    case Horizontal
+    case Vertical
+    
+    /**
+     The principal size is the axis of the direction. Width when the direction is horizontal and height when the direction is vertical.
+     */
+    public func principalSize(size: CGSize) -> CGFloat {
+        switch self {
+        case .Horizontal:
+            return size.width
+        case .Vertical:
+            return size.height
+        }
+    }
+
+    /**
+     The non-principal size is the perpendicular axis of the direction. Height when the direction is horizontal and width when the direction is vertical.
+     */
+    public func nonPrincipalSize(size: CGSize) -> CGFloat {
+        switch self {
+        case .Horizontal:
+            return size.height
+        case .Vertical:
+            return size.width
+        }
+    }
+    
+    /**
+     The principal position is on the axis of the direction. X when the direction is horizontal and Y when the direction is vertical.
+     */
+    public func principalPosition(p: CGPoint) -> CGFloat {
+        switch self {
+        case .Horizontal:
+            return p.x
+        case .Vertical:
+            return p.y
+        }
+    }
+    
+    /**
+     The non-principal position is on the perpendicular axis of the direction. Y when the direction is horizontal and X when the direction is vertical.
+     */
+    public func nonPrincipalPosition(p: CGPoint) -> CGFloat {
+        switch self {
+        case .Horizontal:
+            return p.y
+        case .Vertical:
+            return p.x
+        }
+    }
+    
+    /**
+     The principal size of the direction is applied. Vertical direction will flip the width and the height in the size.
+     */
+    public func getSize(size: CGSize) -> CGSize {
+        switch self {
+        case .Horizontal:
+            return size
+        case .Vertical:
+            return CGSizeMake(size.height, size.width)
+        }
+    }
+    
+    /**
+     The principal position of the direction is applied. Vertical direction will flip the X and the Y in the point.
+     */
+    public func getPosition(p: CGPoint) -> CGPoint {
+        switch self {
+        case .Horizontal:
+            return p
+        case .Vertical:
+            return CGPointMake(p.y, p.x)
+        }
+    }
+}


### PR DESCRIPTION
Added the rounded style with corner radius option
Updated the example to show the vertical snapper

With this update, the SnappingStepper can also be used in a vertical layout style.
The rounded style with fixed corner radius is required when you want to have the same corner radius among multiple components with different sizes in the UI.
I have included the direction enum from MJRFlexStyleComponents in order to ease the layout orientation calculations. The enum is included as-is (public), so that if this PR is accepted and released, then MJRFlexStyleComponents can just use the enum from the SnappingStepper lib.

If this is acceptable, it would be nice with a new release.
